### PR TITLE
Remove the renew argument

### DIFF
--- a/roles/buildmachine.webhook.listener/tasks/main.yml
+++ b/roles/buildmachine.webhook.listener/tasks/main.yml
@@ -125,7 +125,7 @@
   cron:
     name: letsencrypt_renewal_{{ webhook.domain }}
     special_time: weekly
-    job: (letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
+    job: (letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
   when: webhook is defined and webhook.domain is defined
 
 - name: Add message to post_run_messages with webhook.

--- a/roles/grunt-buildmachine/tasks/main.yml
+++ b/roles/grunt-buildmachine/tasks/main.yml
@@ -164,7 +164,7 @@
   cron:
     name: letsencrypt_renewal_{{ buildmachine.build_creds.archiveDomain }}
     special_time: weekly
-    job: (letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
+    job: (letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
   when: >
     buildmachine is defined
     and buildmachine.build_creds is defined

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -47,7 +47,7 @@
   cron:
     name: letsencrypt_renewal_{{ item.name }}
     special_time: weekly
-    job: (letsencrypt --renew certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
+    job: (letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
     and item.name not in domains_to_skip


### PR DESCRIPTION
The `--renew` argument is no more in `letsencrypt`. This was throwing an error when the renewal script was executed by `crontab`.

### Testing:
- This was tested on a working remote server that was setup with a help of this Ansible playbook.