### PR TITLE
Use certbot for certificate creation

### DIFF
--- a/roles/buildmachine.webhook.listener/tasks/main.yml
+++ b/roles/buildmachine.webhook.listener/tasks/main.yml
@@ -101,7 +101,7 @@
   become: yes
 
 - name: Create letsencrypt cert
-  shell: letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }}
+  shell: certbot certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }}
   args:
     creates: /etc/letsencrypt/live/{{ webhook.domain }}
   notify: restart nginx

--- a/roles/buildmachine.webhook.listener/tasks/main.yml
+++ b/roles/buildmachine.webhook.listener/tasks/main.yml
@@ -125,7 +125,7 @@
   cron:
     name: letsencrypt_renewal_{{ webhook.domain }}
     special_time: weekly
-    job: (letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
+    job: (certbot certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ webhook.domain }} --post-hook "service nginx restart") 2>&1 | logger -t letsencrypt_renewal
   when: webhook is defined and webhook.domain is defined
 
 - name: Add message to post_run_messages with webhook.

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Upgrade packages
   apt: upgrade=dist
-  
+
 - name: Install packages
   apt:
     name: "{{ item }}"
@@ -14,3 +14,4 @@
   - unzip
   - python-pip
   - python-dev
+  - python-mysqldb

--- a/roles/grunt-buildmachine/tasks/main.yml
+++ b/roles/grunt-buildmachine/tasks/main.yml
@@ -131,7 +131,7 @@
   become: yes
 
 - name: Create letsencrypt cert
-  shell: letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }}
+  shell: certbot certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }}
   args:
     creates: /etc/letsencrypt/live/{{ buildmachine.build_creds.archiveDomain }}
   notify: restart nginx

--- a/roles/grunt-buildmachine/tasks/main.yml
+++ b/roles/grunt-buildmachine/tasks/main.yml
@@ -164,7 +164,7 @@
   cron:
     name: letsencrypt_renewal_{{ buildmachine.build_creds.archiveDomain }}
     special_time: weekly
-    job: (letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
+    job: (certbot certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ buildmachine.build_creds.archiveDomain }} --post-hook "service nginx restart") 2>&1 | logger -t letsencrypt_renewal
   when: >
     buildmachine is defined
     and buildmachine.build_creds is defined

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -11,7 +11,7 @@
   become: yes
 
 - name: Create letsencrypt certificate
-  shell: letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }}
+  shell: certbot certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }}
   args:
     creates: /etc/letsencrypt/live/{{ item.name }}
   notify: restart nginx

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -47,7 +47,7 @@
   cron:
     name: letsencrypt_renewal_{{ item.name }}
     special_time: weekly
-    job: (letsencrypt certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} && service nginx restart) 2>&1 | logger -t letsencrypt_renewal
+    job: (certbot certonly -n --webroot -w /home/{{ remote_web_user }}/www/letsencrypt -m {{ letsencrypt.email }} --agree-tos -d {{ item.name }} --post-hook "service nginx restart") 2>&1 | logger -t letsencrypt_renewal
   when: >
     (("all" in domains_to_use and "none" in domains_to_skip) or item.name in domains_to_use)
     and item.name not in domains_to_skip


### PR DESCRIPTION
Work here replaces `letsencrypt` with the `certbot` tool.

And fixes an issue with the initial MySQL setup, where Python v2 misses the `mysqldb` module.

### Testing
- This was tested on a local and production servers.